### PR TITLE
Hello, small fix to HTTP calls appending 'undefined' to URL

### DIFF
--- a/core-packages/http/lib/index.jsx
+++ b/core-packages/http/lib/index.jsx
@@ -347,7 +347,7 @@ function HTTPRequest (method, url, timeout) {
 		// request line
 		var head = [];
 		var url = this.url();
-		var path = url.pathname + url.search;
+		var path = url.pathname + (url.search || "");
 		var request_line = "{} {} HTTP/1.1".format(this.method(), path || "/");
 		head.push(request_line);
 		// headers to string (kv) form


### PR DESCRIPTION
Hello,

I was trying to make calls to dx.doi.org 's site using Extendables, but I noticed an appending of "undefined" to the end of my called URL, which would then cause the site to give me a 'DOI not found' error. I seemed to find the place where this was happening, and I made it so that if url.search was undefined, it would default to a blank string, which wouldn't affect the HTTP call.

Hopefully this change is useful,

Nukleas

... (url.search was undefined, would concatenate undefined to end of url)
