### PR TITLE
HTTP package: fix URL building

### DIFF
--- a/core-packages/http/lib/index.jsx
+++ b/core-packages/http/lib/index.jsx
@@ -347,7 +347,12 @@ function HTTPRequest (method, url, timeout) {
 		// request line
 		var head = [];
 		var url = this.url();
-		var path = url.pathname + url.search;
+		var path;
+		if (url.search) {
+			path = url.pathname + url.search;
+		} else {
+			path = url.pathname;
+		}
 		var request_line = "{} {} HTTP/1.1".format(this.method(), path || "/");
 		head.push(request_line);
 		// headers to string (kv) form


### PR DESCRIPTION
If a URL has no query string, the HTTP package added the string 'undefined' to the end of the URL.

This fix reduces the failing assertions in the existing tests for the HTTP package from 8 to 1 (using InDesign CS6 as the environment).

This fix is similar to pull request #23.
